### PR TITLE
fix: impl transaction return value handling for IPARegistrar

### DIFF
--- a/execution/crates/registrar/src/lib.rs
+++ b/execution/crates/registrar/src/lib.rs
@@ -51,28 +51,52 @@ pub async fn register_ip(
         nftMetadata: nft_metadata,
     };
 
-    let hash = contract
-        .register(address, imetadata)
+    // Step 1: Send the transaction and get initial response
+    // The `send()` method submits the transaction to the blockchain and returns
+    // a transaction handle that we can use to track its status
+    let tx = contract
+        .register(address, imetadata.clone())
         .from(signer.address())
         .send()
+        .await?;
+
+    // Step 2: Wait for transaction confirmation
+    // `get_receipt()` waits for the transaction to be mined and returns the receipt
+    // This ensures our transaction has been processed by the network
+    let receipt = tx.get_receipt().await?;
+    let tx_hash = receipt.transaction_hash;
+
+    // Step 3: Get the transaction receipt
+    // The receipt contains important information about the transaction execution
+    let receipt = provider
+        .get_transaction_receipt(tx_hash)
         .await?
-        .get_receipt()
+        .ok_or_else(|| eyre::eyre!("Receipt not found"))?;
+
+    // Step 4: Extract the transaction data
+    // We'll need to get the transaction to access its input data
+    let tx = provider
+        .get_transaction_by_hash(tx_hash)
         .await?
-        .transaction_hash;
-    let input = hex::decode(
-        provider
-            .get_transaction_by_hash(hash)
-            .await?
-            .unwrap()
-            .inner
-            .input(),
-    )
-    .unwrap();
+        .ok_or_else(|| eyre::eyre!("Transaction not found"))?;
+
+    // Step 5: Get the function output from the logs or use a View call
+    // Since this is a state-changing function, we need to either:
+    // a) Parse event logs if the contract emits an event with the IPID
+    // b) Make a separate view call to get the IPID if the contract provides a getter
+    // For now, we'll use a view call right after the transaction
+    // Get the return value and extract the address from it
+    let register_return = contract
+        .register(address, imetadata.clone())
+        .call()
+        .await?;
+    
+    // The register function returns a tuple with one field (the address)
+    // We need to extract that address
+    let ipid = register_return._0;
+
     Ok(IPData {
-        ipid: IPARegistrar::registerCall::abi_decode_returns(&input, true)
-            .unwrap()
-            ._0
-            .clone(),
-        hash,
+        ipid,
+        hash: tx_hash,
     })
 }


### PR DESCRIPTION
the current implementation fails to properly capture the return value (IPID address) from the IPARegistrar's register function. to my knowledge, when dealing with state-changing Ethereum transactions, return values aren't directly accessible through the transaction receipt

i transitioned from attempting to decode the return value from transaction input data to using a simulated call approach. here's what changed:

- original approach tried to decode transaction input:
```rust
let input = hex::decode(provider.get_transaction_by_hash(hash)?.unwrap().input())?;
let ipid = IPARegistrar::registerCall::abi_decode_returns(&input, true)?._0;
```
- new approach uses a simulated call after transaction confirmation
```rust
let register_return = contract.register(address, imetadata.clone()).call().await?;
let ipid = register_return._0;
```

## this is a PoC and it's got limitations we can improve

- makes redundant contract calls:
One for the actual state-changing transaction
Another for the simulated call to get the return value

- the simulated call might not perfectly reflect the transaction's actual result
- lacks proper error typing and handling

## suggested Improvements
- add an event to capture the IPID:
```solidity
event RegisterComplete(
    address indexed ipid,
    address indexed registrant,
    bytes32 indexed txHash
);
```
this would allow us to reliably capture the IPID from transaction logs.

- implement specific error types:
```rust
pub enum RegisterError {
    TransactionFailed(String),
    ReceiptNotFound(H256),
    SimulationFailed(String),
    InvalidReturnValue,
}
```

- reduce RPC calls by consolidating the transaction monitoring:
```rust
\\ instead of separate calls for receipt and transaction
let (receipt, tx) = tokio::try_join!(
    provider.get_transaction_receipt(tx_hash),
    provider.get_transaction_by_hash(tx_hash)
)?;
```

- add test coverage for:
transaction success/failure scenarios
return value validation
error cases
gas estimation